### PR TITLE
Close html list element when using Bootstrap 3

### DIFF
--- a/lib/alphabetical_paginate/view_helpers.rb
+++ b/lib/alphabetical_paginate/view_helpers.rb
@@ -56,7 +56,7 @@ module AlphabeticalPaginate
         (params[:bootstrap3] ? "" : "<ul>") +
         links +
         (params[:bootstrap3] ? "" : "</ul>") +
-        (params[:bootstrap3] ? "" : "</div>")
+        (params[:bootstrap3] ? "</ul>" : "</div>")
 
       output += pagination
       output.html_safe


### PR DESCRIPTION
- When the Bootstrap 3 flag is set, a `<ul>` tag is opened rather than a `<div>`. This also needs to be closed at the end.

Fixes #22
