### PR TITLE
Deal with anchor links + Old browser check

### DIFF
--- a/vendor/assets/javascripts/alphabetical_paginate.js
+++ b/vendor/assets/javascripts/alphabetical_paginate.js
@@ -1,5 +1,6 @@
 $(function() {
-  var once = false;
+  // deal with old browsers
+  var hasHistory = !!(window.history && window.history.pushState);
 
   var img = "<img src='/assets/aloader.gif' class='loading'/>";
   // RAILS 3.0 USERS -> Please delete the above line and uncomment the bottom line
@@ -12,45 +13,50 @@ $(function() {
 
   if (!handlers || -1 !== $.inArray(onNavbarClick, handlers.click)) {
       $(document).on("click", ".pagination.alpha a", onNavbarClick);
-      bindPopState();
+      if(hasHistory){
+        // bind the popstate
+        bindPopState(location.href);
+      }
   }
 
   function onNavbarClick(e) {
       e.preventDefault();
-      var url = location.href, 
-      letter = $(this).data("letter");
+      var url = location.href,
+          letter = $(this).data("letter");
       if (/letter/.test(url)) {
           url = url.replace(/letter=[^&]*/, "letter=" + letter);
-      } 
-      else {
+      } else {
           if (/\?/.test(url)) {
               url += "&letter=" + letter;
-          } 
-          else {
+          } else {
               url += "?letter=" + letter;
           }
       }
-      $(".pagination").html(img);
-      //$.load(url + " #pagination_table");
-      $.get(url, function(result) {
-          $(".pagination").html($(".pagination", result).html());
-          $("#pagination_table").html($("#pagination_table", result).html());
-      });
-      history.pushState(null, document.title, url);
+      loadPage(url);
+      // deal with browser support
+      if(hasHistory){
+        history.pushState(null, document.title, url);
+      }
   }
 
   // let navigate the browser throught the ajax history
-  function bindPopState(){
+  function bindPopState(initialUrl){
     $(window).bind("popstate", function() {
-      if (once) {
-        $(".pagination").html(img);
-        $.get(location.href, function(result) {
-          $(".pagination").html($(".pagination", result).html());
-            $("#pagination_table").html($("#pagination_table", result).html());
-          });
-        } else {
-          once = true;
-        }
+      var newUrl = location.href;
+      var diff = newUrl.replace(initialUrl, '');
+      // skip initial popstate
+      // skip anchor links (used for JS links)
+      if (diff !== '' && diff !== '#') {
+        loadPage(newUrl);
+      }
+    });
+  }
+
+  function loadPage(url){
+    $(".pagination").html(img);
+    $.get(url, function (result) {
+      $(".pagination").html($(".pagination", result).html());
+      $("#pagination_table").html($("#pagination_table", result).html());
     });
   }
 


### PR DESCRIPTION
This fix has been done in order to deal with anchor links within the paginated table - also used to trigger some JS actions.
Also the fix takes care of the first `state` change that happens on page load.
More, the fix also deal with old browsers who don't support `window.history`
