### PR TITLE
Ensure 'All' remains at the front of the pagination array

### DIFF
--- a/lib/alphabetical_paginate/view_helpers.rb
+++ b/lib/alphabetical_paginate/view_helpers.rb
@@ -34,7 +34,11 @@ module AlphabeticalPaginate
       else
         options[:availableLetters].sort!
         options[:availableLetters] = options[:availableLetters][1..-1] + ["*"] if options[:availableLetters][0] == "*"
-        options[:availableLetters].unshift "All" if (options[:include_all] && !options[:availableLetters].include?("All"))
+        #Ensure that "All" is always at the front of the array
+        if options[:include_all]
+          options[:availableLetters].delete("All") if options[:availableLetters].include?("All")
+          options[:availableLetters].unshift("All")
+        end
         options[:availableLetters] -= (1..9).to_a.map{|x| x.to_s} if !options[:numbers]
         options[:availableLetters] -= ["*"] if !options[:others]
         


### PR DESCRIPTION
There was an issue where if you include all and then multiple alphabetical_paginate calls the first would appear as:

All, A, B, C, D....

But all subsequent alphabetical_paginate calls (on the same page) would produce:

A, All, B, C, D....

This was due to how it was checking and sorting. Just simply updated it to ensure "All" is always first to avoid inconsistency.