### PR TITLE
Make paginate_all=false work also in DB mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ The available options are as follows:
 
 Key | Value | Default |Description
 --- | --- | --- | ---
-`:db_mode` | `Boolean` | `false` | Whether to activate low level SQL that are faster and more memory efficient (forces `:paginate_all` to enable)
+`:db_mode` | `Boolean` | `false` | Whether to activate low level SQL that are faster and more memory efficient
 `:db_field` | `String` | `id` | Required if `db_mode` is `true`. The field to paginate / sort by (on the same collection).
 `:enumerate` | `Boolean` | `false` | Whether you want the number field collapsed (all numbers go into `0`) or separate (`0`, `1`, `2`...).
 `:default_field` | `String` | `"a"` | Which field you want the page to default to on first load (`"0"`, `"a"`. `"*"`).
-`:paginate_all` | `Boolean` | `false` | Whether you want empty fields to still render in pagination.
+`:paginate_all` | `Boolean` | `false` | Whether you want empty fields to still render in pagination. If it's falsy and `db_mode` is thruty is will perform one more aggregation query: set it to true if performances matter.
 `:include_all` | `Boolean` | `true` | Whether you want `all` selector to be included in the pagination.
 `:numbers` | `Boolean` | `true` | Whether you want numbers to be included in the pagination at all, either collapsed, or expanded (depending on `:enumerate`).
 `:others` | `Boolean` | `true` | Whether you want all other characters (non alphanumeric) to be included in the pagination at all.

--- a/lib/alphabetical_paginate/controller_helper.rb
+++ b/lib/alphabetical_paginate/controller_helper.rb
@@ -20,11 +20,25 @@ module AlphabeticalPaginate
       params[:js] = true if !params.has_key? :js
       params[:pagination_class] ||= "pagination-centered"
       params[:batch_size] ||= 500
-      params[:default_field] ||= params[:include_all] ? "all" : params[:language].default_letter
+      # params[:default_field] ||= params[:include_all] ? "all" : params[:language].default_letter
       params[:db_mode] ||= false
       params[:db_field] ||= "id"
 
       output = []
+      
+      if params[:include_all]
+        current_field ||= 'all'
+        all = current_field == "all"
+      end
+      
+      if params[:db_mode]
+        letters = nil
+        if !all && !params[:paginate_all]
+          letters = filter_by_cardinality( find_available_letters(params[:db_field]) )
+          set_default_field letters, params
+        end
+        params[:availableLetters] = letters.any? ? letters : []
+      end
 
       current_field ||= params[:default_field]
       current_field = current_field.mb_chars.downcase.to_s
@@ -34,8 +48,6 @@ module AlphabeticalPaginate
         if !ActiveRecord::Base.connection.adapter_name.downcase.include? "mysql"
           raise "You need a mysql database to use db_mode with alphabetical_paginate"
         end
-        params[:paginate_all] = true
-        params[:availableLetters] = []
 
         if all
           output = self
@@ -57,7 +69,6 @@ module AlphabeticalPaginate
             regexp_to_check = current_field =~ /[0-9]/ ? '^[0-9]' : '^[^a-z0-9]'
             output = self.where("LOWER(%s) REGEXP '%s.*'" % [params[:db_field], regexp_to_check])
           end
-          
         end
       else
         availableLetters = {}
@@ -86,6 +97,31 @@ module AlphabeticalPaginate
       end
       params[:currentField] = current_field.mb_chars.capitalize.to_s
       return ((params[:db_mode] && params[:db_field]) ? output.order("#{params[:db_field]} ASC") : output), params
+    end
+
+    private
+
+    def set_default_field(letters, params)
+      if letters.any?
+        params[:default_field] = letters.first
+      elsif @params[:include_all]
+        params[:default_field] = 'all'
+      else
+        params[:default_field] = params[:language].default_letter
+      end
+    end
+
+    def filter_by_cardinality(letters)
+      letters.collect { |l, n| n > 0 ? l.mb_chars.capitalize.to_s : nil }
+    end
+
+    def find_available_letters(db_field)
+      # safe the field (look for the ActiveRecord valid attributes)
+      if db_field.nil? || !self.attributes.has_key? db_field
+        db_field = 'id'
+      end
+      criteria = "substr( %s, 1 , 1)" % db_field
+      self.select(criteria).group(criteria).order(criteria).count(db_field)
     end
   end
 end

--- a/lib/alphabetical_paginate/controller_helper.rb
+++ b/lib/alphabetical_paginate/controller_helper.rb
@@ -124,7 +124,7 @@ module AlphabeticalPaginate
 
     def find_available_letters(db_field)
       # safe the field (look for the ActiveRecord valid attributes)
-      if db_field.nil? || !self.attributes.has_key? db_field
+      if (db_field.nil? || !self.attributes.has_key? db_field)
         db_field = 'id'
       end
       criteria = "substr( %s, 1 , 1)" % db_field

--- a/lib/alphabetical_paginate/controller_helper.rb
+++ b/lib/alphabetical_paginate/controller_helper.rb
@@ -115,11 +115,12 @@ module AlphabeticalPaginate
       letters.collect do |letter, count|
         if count > 0
           letter = letter.mb_chars.capitalize.to_s
-          (letter =~ /[a-z]/).nil? ? '*' : letter
+          (letter =~ /[A-Z]/).nil? ? '*' : letter
         else
           nil
         end
-      end
+      # repass again to filter duplicates *
+      end.uniq
     end
 
     def find_available_letters(db_field)

--- a/lib/alphabetical_paginate/controller_helper.rb
+++ b/lib/alphabetical_paginate/controller_helper.rb
@@ -20,7 +20,6 @@ module AlphabeticalPaginate
       params[:js] = true if !params.has_key? :js
       params[:pagination_class] ||= "pagination-centered"
       params[:batch_size] ||= 500
-      # params[:default_field] ||= params[:include_all] ? "all" : params[:language].default_letter
       params[:db_mode] ||= false
       params[:db_field] ||= "id"
 

--- a/lib/alphabetical_paginate/controller_helper.rb
+++ b/lib/alphabetical_paginate/controller_helper.rb
@@ -104,7 +104,7 @@ module AlphabeticalPaginate
     def set_default_field(letters, params)
       if letters.any?
         params[:default_field] = letters.first
-      elsif @params[:include_all]
+      elsif params[:include_all]
         params[:default_field] = 'all'
       else
         params[:default_field] = params[:language].default_letter
@@ -112,7 +112,14 @@ module AlphabeticalPaginate
     end
 
     def filter_by_cardinality(letters)
-      letters.collect { |l, n| n > 0 ? l.mb_chars.capitalize.to_s : nil }
+      letters.collect do |letter, count|
+        if count > 0
+          letter = letter.mb_chars.capitalize.to_s
+          letter =~ /[a-z]/ ? letter : '*'
+        else
+          nil
+        end
+      end
     end
 
     def find_available_letters(db_field)

--- a/lib/alphabetical_paginate/view_helpers.rb
+++ b/lib/alphabetical_paginate/view_helpers.rb
@@ -39,7 +39,7 @@ module AlphabeticalPaginate
         options[:availableLetters] -= ["*"] if !options[:others]
         
         options[:availableLetters].each do |l|
-          url = options[:scope].url_for(options.merge(:letter => l))
+          url = options[:scope].url_for({:letter => l})
           value = options[:language].output_letter(l)
           links += content_tag(:li, link_to(value, url, "data-letter" => l), :class => ("active" if l == options[:currentField] ))
         end


### PR DESCRIPTION
This pull request let's the user use the `paginate_all` option of the gem also when `db_mode` is on, performing one more query to the db.

It does also check for a meaninful `default_field` to set in case the given one has no values in it: this make the gem present always a page with some content in case the passed `current_field` is not set.