### PR TITLE
remove options' noise from url

### DIFF
--- a/lib/alphabetical_paginate/view_helpers.rb
+++ b/lib/alphabetical_paginate/view_helpers.rb
@@ -19,9 +19,9 @@ module AlphabeticalPaginate
         end
         range.unshift "All" if (options[:include_all] && !range.include?("All"))
         range.each do |l|
-          
-          url = options[:scope].url_for(options.merge(:letter => l))
-          
+
+          url = options[:scope].url_for(:letter => l)
+
           value = options[:language].output_letter(l)
           if l == options[:currentField]
             links += content_tag(:li, link_to(value, "#", "data-letter" => l), :class => "active")
@@ -43,7 +43,7 @@ module AlphabeticalPaginate
         options[:availableLetters] -= ["*"] if !options[:others]
         
         options[:availableLetters].each do |l|
-          url = options[:scope].url_for(options.merge(:letter => l))
+          url = options[:scope].url_for(:letter => l)
           value = options[:language].output_letter(l)
           links += content_tag(:li, link_to(value, url, "data-letter" => l), :class => ("active" if l == options[:currentField] ))
         end


### PR DESCRIPTION
Hello

Need to clean options' noise from urls
![alphabetical_paginate_noise_in_url](https://cloud.githubusercontent.com/assets/482439/7167242/eaf39806-e3cc-11e4-9600-576d0e9b7152.png)
