### PR TITLE
add all_as_link to params for using '?letter=All' optional

### DIFF
--- a/lib/alphabetical_paginate/array.rb
+++ b/lib/alphabetical_paginate/array.rb
@@ -4,7 +4,7 @@ class Array
                                               paginate_all: false, numbers: true, include_all: true,
                                               others: true, pagination_class: "pagination-centered",
                                               js: true, support_language: :en, bootstrap3: false,
-                                              slugged_link: false, slug_field: "slug"}
+                                              slugged_link: false, slug_field: "slug", all_as_link: true}
     params[:paginate_all] ||= false
     params[:support_language] ||= :en
     params[:language] = AlphabeticalPaginate::Language.new(params[:support_language])
@@ -17,6 +17,7 @@ class Array
     params[:slugged_link] ||= false
     params[:slugged_link] = params[:slugged_link] && defined?(Babosa)
     params[:slug_field] ||= "slug"
+    params[:all_as_link] = true if !params.has_key? :all_as_link
 
     output = []
     availableLetters = {}

--- a/lib/alphabetical_paginate/controller_helper.rb
+++ b/lib/alphabetical_paginate/controller_helper.rb
@@ -11,7 +11,7 @@ module AlphabeticalPaginate
                                                 db_field: "id", include_all: true,
                                                 js: true, support_language: :en,
                                                 bootstrap3: false, slugged_link: false,
-                                                slug_field: "slug"}
+                                                slug_field: "slug", all_as_link: true}
       params[:paginate_all] ||= false
       params[:support_language] ||= :en
       params[:language] = AlphabeticalPaginate::Language.new(params[:support_language])
@@ -26,6 +26,7 @@ module AlphabeticalPaginate
       params[:slugged_link] ||= false
       params[:slugged_link] = params[:slugged_link] && defined?(Babosa)
       params[:slug_field] ||= "slug"
+      params[:all_as_link] = true if !params.has_key? :all_as_link
 
       output = []
       

--- a/lib/alphabetical_paginate/view_helpers.rb
+++ b/lib/alphabetical_paginate/view_helpers.rb
@@ -23,8 +23,12 @@ module AlphabeticalPaginate
           if options[:slugged_link] && (l =~ options[:language].letters_regexp || l == "All")
             link_letter = options[:language].slugged_letters[l]
           end
+          letter_options = { letter: link_letter }
+          if !options[:all_as_link] && (l == "All")
+            letter_options[:letter] = nil
+          end
 
-          url = options[:scope].url_for(:letter => link_letter)
+          url = options[:scope].url_for(letter_options)
           value = options[:language].output_letter(l)
           if l == options[:currentField]
             links += content_tag(:li, link_to(value, "#", "data-letter" => l), :class => "active")
@@ -50,8 +54,12 @@ module AlphabeticalPaginate
           if options[:slugged_link] && (l =~ options[:language].letters_regexp || l == "All")
             link_letter = options[:language].slugged_letters[l]
           end
+          letter_options = { letter: link_letter }
+          if !options[:all_as_link] && (l == "All")
+            letter_options[:letter] = nil
+          end
 
-          url = options[:scope].url_for(:letter => link_letter)
+          url = options[:scope].url_for(letter_options)
           value = options[:language].output_letter(l)
           links += content_tag(:li, link_to(value, url, "data-letter" => l), :class => ("active" if l == options[:currentField] ))
         end

--- a/spec/alphabetical_paginate_spec.rb
+++ b/spec/alphabetical_paginate_spec.rb
@@ -15,7 +15,7 @@ end
 
 class RouterMock
   def url_for(options)
-    '?letter='+options[:letter]
+    options[:letter] ? '?letter='+options[:letter] : '/'
   end
 end
 
@@ -200,6 +200,18 @@ module AlphabeticalPaginate
           'data-letter="%s"'%x}).each do |x|
           pagination.should include x
         end
+      end
+
+      it "should include All as link" do
+        index, params = @list.alpha_paginate("A", { include_all: true })
+        pagination = alphabetical_paginate(params)
+        pagination.should include "href='?letter=All'"
+      end
+
+      it "should not include All as link" do
+        index, params = @list.alpha_paginate("A", { include_all: true, all_as_link: false })
+        pagination = alphabetical_paginate(params)
+        pagination.should_not include "href='?letter=All'"
       end
     end
 


### PR DESCRIPTION
Hello.

If `include_all` option is set to true, we'll have two urls /dictionary and /dictionary?letter=All. From point of SEO these urls are similar and it's not permissible. 
To avoid this problem need to use `all_as_link` option. if it's set to false, we'll have only one url is /dictionary.