### PR TITLE
Close `ul` when using bootstrap3 mode

### DIFF
--- a/lib/alphabetical_paginate/view_helpers.rb
+++ b/lib/alphabetical_paginate/view_helpers.rb
@@ -75,7 +75,7 @@ module AlphabeticalPaginate
         (options[:bootstrap3] ? "" : "<ul>") +
         links +
         (options[:bootstrap3] ? "" : "</ul>") +
-        (options[:bootstrap3] ? "" : "</div>")
+        "</#{element}>"
 
       output += pagination
       output.html_safe

--- a/lib/alphabetical_paginate/view_helpers.rb
+++ b/lib/alphabetical_paginate/view_helpers.rb
@@ -6,7 +6,7 @@ module AlphabeticalPaginate
       links = ""
       output += javascript_include_tag 'alphabetical_paginate' if options[:js] == true
       options[:scope] ||= main_app
-      
+
       if options[:paginate_all]
         range = options[:language].letters_range
         if options[:others]
@@ -48,7 +48,7 @@ module AlphabeticalPaginate
         end
         options[:availableLetters] -= (1..9).to_a.map{|x| x.to_s} if !options[:numbers]
         options[:availableLetters] -= ["*"] if !options[:others]
-        
+
         options[:availableLetters].each do |l|
           link_letter = l
           if options[:slugged_link] && (l =~ options[:language].letters_regexp || l == "All")

--- a/spec/alphabetical_paginate_spec.rb
+++ b/spec/alphabetical_paginate_spec.rb
@@ -144,6 +144,20 @@ module AlphabeticalPaginate
         pagination.should include "div", "pagination"
       end
 
+      it "should open and close the div tag" do
+        index, params = @list.alpha_paginate(nil)
+        pagination = alphabetical_paginate(params)
+        pagination.start_with?('<div').should be_truthy
+        pagination.end_with?('</div>').should be_truthy
+      end
+
+      it "should open and close the ul tag when run in bootstrap3 mode" do
+        index, params = @list.alpha_paginate(nil)
+        pagination = alphabetical_paginate(params.merge(bootstrap3: true))
+        pagination.start_with?('<ul').should be_truthy
+        pagination.end_with?('</ul>').should be_truthy
+      end
+
       it "should include a numbers and others field" do
         index, params = @list.alpha_paginate(nil)
         pagination = alphabetical_paginate(params)

--- a/spec/alphabetical_paginate_spec.rb
+++ b/spec/alphabetical_paginate_spec.rb
@@ -55,7 +55,7 @@ module AlphabeticalPaginate
           enumerate: false,
         }
         collection, params = @list.alpha_paginate("b")
-        collection.to_s.should == 
+        collection.to_s.should ==
           expectedCollection.to_s
         params.to_s.should include
           expectedParams.to_s
@@ -73,7 +73,7 @@ module AlphabeticalPaginate
         collection, params = @list.alpha_paginate("b") do |x|
           x.word
         end
-        collection.to_s.should == 
+        collection.to_s.should ==
           expectedCollection.to_s
         params.to_s.should include
           expectedParams.to_s
@@ -100,7 +100,7 @@ module AlphabeticalPaginate
           enumerate: false,
         }
         collection, params = @list.alpha_paginate("с", { support_language: :ru })
-        collection.to_s.should == 
+        collection.to_s.should ==
           expectedCollection.to_s
         params.to_s.should include
           expectedParams.to_s
@@ -116,7 +116,7 @@ module AlphabeticalPaginate
           enumerate: false,
         }
         collection, params = @list.alpha_paginate(nil, { include_all: false, support_language: :ru })
-        collection.to_s.should == 
+        collection.to_s.should ==
           expectedCollection.to_s
         params.to_s.should include
           expectedParams.to_s


### PR DESCRIPTION
This fixes #22 again.  #23 fixed it and was released as v2.2.3, but then #24 overwrote that and so v2.3.0+ have a regression.