### PR TITLE
Wrap SQL with Arel.sql in ControllerHelpers.find_available_letters

### DIFF
--- a/lib/alphabetical_paginate/controller_helper.rb
+++ b/lib/alphabetical_paginate/controller_helper.rb
@@ -139,7 +139,7 @@ module AlphabeticalPaginate
       if db_field.nil? || !self.attribute_names.include?(db_field.to_s.split('.').last)
         db_field = 'id'
       end
-      criteria = "substr( %s, 1 , 1)" % db_field
+      criteria = Arel.sql("substr( %s, 1 , 1)" % db_field)
       self.select(criteria).group(criteria).order(criteria).count(db_field)
     end
   end


### PR DESCRIPTION
This prepares alphabetical_paginate to work with Rails 6, where
non-attribute arguments will be disallowed.

Below is an example of a deprecation warning that shows up without
this change:

```
DEPRECATION WARNING: Dangerous query method (method whose arguments
are used as raw SQL) called with non-attribute argument(s): "substr(
users.name, 1 , 1)". Non-attribute arguments will be disallowed in
Rails 6.0. This method should not be called with user-provided values,
such as request parameters or model attributes. Known-safe values can
be passed by wrapping them in Arel.sql().
```