### PR TITLE
Bumped to v2.3.4

### DIFF
--- a/lib/alphabetical_paginate/version.rb
+++ b/lib/alphabetical_paginate/version.rb
@@ -1,3 +1,3 @@
 module AlphabeticalPaginate
-  VERSION = "2.3.3"
+  VERSION = "2.3.4"
 end


### PR DESCRIPTION
The only change since v2.3.3 is https://github.com/lingz/alphabetical_paginate/commit/26015e94c64f4feaeac756ab7c3512b0707e96be. 

We'd like to be able to use this version in our apps using rubygems if possible?